### PR TITLE
Fix Dockerfile to remove chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # jdk8 has a bug. Ref: https://bugs.openjdk.java.net/browse/JDK-8067747
 FROM maven:3.6.3-openjdk-8-slim as builder
 
-COPY --chown=maven:maven . /sns-crawler
+COPY . /sns-crawler
 WORKDIR /sns-crawler
 RUN mvn clean package -Dmaven.test.skip=true
 


### PR DESCRIPTION
To fix the following error:
```
Step 2/14 : COPY --chown=maven:maven . /sns-crawler
unable to convert uid/gid chown string to host mapping: can't find uid for user maven: no such user: maven
```