### PR TITLE
Fix test

### DIFF
--- a/src/test/java/codes/dirty/sns/crawler/ApplicationTests.java
+++ b/src/test/java/codes/dirty/sns/crawler/ApplicationTests.java
@@ -1,13 +1,16 @@
 package codes.dirty.sns.crawler;
 
 import codes.dirty.sns.crawler.common.config.DiscordProperty;
+import codes.dirty.sns.crawler.common.config.NoScheduleTestConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
+@Import(NoScheduleTestConfiguration.class)
 class ApplicationTests {
 
     @Autowired

--- a/src/test/java/codes/dirty/sns/crawler/common/config/NoScheduleTestConfiguration.java
+++ b/src/test/java/codes/dirty/sns/crawler/common/config/NoScheduleTestConfiguration.java
@@ -1,0 +1,13 @@
+package codes.dirty.sns.crawler.common.config;
+
+import codes.dirty.sns.crawler.module.spotv.service.SpotvSchedulingService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@TestConfiguration
+public class NoScheduleTestConfiguration {
+    @MockBean
+    SchedulingConfiguration schedulingConfiguration;
+    @MockBean
+    SpotvSchedulingService spotvSchedulingService;
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+## test/resources/application.yml
+
+discord:
+    endpoint:
+    channel: 일반
+    keywords:
+        - 토트넘
+        - 맨유


### PR DESCRIPTION
테스트를 돌리는데 ApplicationContext 로드 오류가 나는 부분을 공통으로 예외처리하는 TestConfiguration 과 test-application.yml 설정을 임시로 추가했습니다.

추가적인 수정 필요사항은 논의가 필요해 보여 이슈에 추가해둘 예정입니다.